### PR TITLE
Correct package name for JsxAssetFile in _Events.groovy

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,3 +1,3 @@
 eventAssetPrecompileStart = { assetConfig ->
-  assetConfig.specs << 'asset.pipeline.jsx.JsxAssetFile'
+  assetConfig.specs << 'asset.pipeline.JsxAssetFile'
 }


### PR DESCRIPTION
Wrong package name is causing the war building process to fail. Error:
| Precompiling Assets!.
| Error WAR packaging error: asset.pipeline.jsx.JsxAssetFile